### PR TITLE
Encryption seems broken

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,8 @@
     "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "pods": "npx pod-install"
   },
   "dependencies": {
     "@waku/react-native": "file:../",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -434,7 +434,7 @@ export function decodeAsymmetric(
   return new Promise<DecodedPayload>(async (resolve, reject) => {
     let messageJSON = JSON.stringify(msg);
     let response = JSON.parse(
-      await ReactNative.decodeSymmetric(messageJSON, privateKey)
+      await ReactNative.decodeAsymmetric(messageJSON, privateKey)
     );
     if (response.error) {
       reject(response.error);


### PR DESCRIPTION
I am trying to use lightpush with asymmetric encryption, but am getting the following error when trying to send a message:

```
json: cannot unmarshal string into Go struct field WakuMessage.timestamp of type int64
```

Since timestamp is optional, I go ahead and remove it and the message is published.

I'm reading the message from a store, but when I call `decodeAsymmetric` I am getting this message:

```
json: cannot unmarshal object into Go struct field WakuMessage.payload of type []uint8
```

Here is an example repo that demonstrates the issue https://github.com/waku-org/waku-react-native/compare/master...bricestacey:waku-react-native:encrypt-bug

I have successfully used lightpush without encryption, so I know that part is working. Relay encryption also breaks.

the message that I get from the store looks like this:

```
{"contentTopic": "chat", "payload": [4, 73, 59, 4, 88, 194, 41, 97, 59, 66, 51, 216, 127, 79, 53, 76, 142, 67, 69, 163, 83, 42, 82, 58, 71, 135, 54, 70, 234, 227, 74, 66, 147, 147, 140, 6, 226, 136, 127, 136, 50, 226, 12, 4, 222, 21, 114, 56, 36, 124, 121, 18, 196, 192, 156, 127, 174, 204, 100, 121, 155, 149, 208, 221, 12, 29, 69, 217, 155, 18, 232, 211, 1, 25, 248, 244, 158, 7, 195, 206, 184, 99, 169, 145, 248, 120, 170, 218, 128, 218, 139, 246, 44, 169, 170, 217, 140, 205, 85, 56, 224, 114, 159, 61, 144, 60, 34, 101, 87, 98, 25, 116, 178, 55, 106, 33, 107, 35, 107, 82, 154, 234, 96, 48, 11, 47, 255, 65, 162, 60, 25, 163, 139, 8, 99, 220, 20, 46, 36, 62, 147, 10, 159, 124, 103, 82, 207, 47, 219, 246, 206, 105, 55, 57, 23, 15, 22, 138, 21, 83, 247, 152, 147, 248, 64, 139, 34, 147, 21, 61, 73, 46, 183, 81, 148, 135, 242, 64, 57, 51, 123, 34, 185, 167, 130, 248, 238, 59, 249, 61, 64, 15, 26, 78, 177, 15, 100, 156, 112, 132, 127, 28, 104, 225, 70, 215, 85, 216, 253, 120, 98, 175, 102, 165, 90, 129, 138, 141, 164, 159, 9, 154, 45, 216, 155, 100, 240, 28, 13, 64, 243, 53, 177, 148, 192, 7, 74, 204, 226, 18, 144, 21, 53, 85, 204, 157, 165, 103, 202, 246, 72, 56, 143, 43, 67, 67, 90, 47, 37, 136, 76, 83, 135, 163, 226, 112, 251, 201, 239, 97, 128, 10, 184, 17, 123, 214, 164, 131, 22, 134, 86, 41, 217, 244, 50, 27, 117, 15, 53, 151, 73, 225, 77, 87, 60, 21, 21, 19, 211, 154, 48, 184, 164, 51, 40, 19, 226, 191, 148, 229, 143, 234, 200, 160, 249, 6, 22, 133, 4, 232, 83, 16, 27, 86, 33, 122, 154, 12, 57, 166, 219, 133, 30, 24, 197, 172, 234, 217, 62, 132, 154, 127, 92, 195, 189, 150, 77, 219, 217, 227, 183, 179, 213, 72, 50, 155, 16, 80, 64, 22, 163, 222, 252, 104, 83, 0, 48, 3, 204], "timestamp": 1970-01-01T00:00:00.000Z, "version": 1}
```