### PR TITLE
update wakuv2 fleet DNS discovery enrtree

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -107,7 +107,7 @@ export default function App() {
       // DNS Discovery
       console.log('Retrieving Nodes using DNS Discovery');
       const dnsDiscoveryResult = await dnsDiscovery(
-        'enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im',
+        'enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im',
         '1.1.1.1'
       );
       console.log(dnsDiscoveryResult);


### PR DESCRIPTION
Enrtrees were regenerated. Need to update the old one.
DNS discoverty should continue to work.